### PR TITLE
add python-apt install for raspberry pi

### DIFF
--- a/test_install/saltstack/debian.sls
+++ b/test_install/saltstack/debian.sls
@@ -11,6 +11,11 @@
 
 {% set key_url = '{0}/SALTSTACK-GPG-KEY.pub'.format(repo_url) %}
 
+{% if params.on_deb_7 %}
+{% set key_url = 'http://' + key_url.split('https://')[1] %}
+{% endif %}
+{% set repo_url = 'http://' + repo_url.split('https://')[1] %}
+
 {% if params.os == 'Raspbian' %}
 install-python-apt:
   pkg.installed:

--- a/test_install/saltstack/debian.sls
+++ b/test_install/saltstack/debian.sls
@@ -11,6 +11,11 @@
 
 {% set key_url = '{0}/SALTSTACK-GPG-KEY.pub'.format(repo_url) %}
 
+{% if params.os == 'Raspbian' %}
+install-python-apt:
+  pkg.installed:
+    - name: python-apt
+{% endif %}
 
 install-https-transport:
   pkg.installed:


### PR DESCRIPTION
In order to run the `pkgrepo.managed` state for raspberry pi it requires the `python-apt` package.
