### PR TITLE
increase timeout for deb7

### DIFF
--- a/test_setup/init.sls
+++ b/test_setup/init.sls
@@ -58,7 +58,7 @@ enable_services:
 
 wait_for_key:
   cmd.run:
-    - name: sleep 17
+    - name: sleep 30
     - require:
       - cmd: enable_services
 


### PR DESCRIPTION
Running into issues with deb7 and waiting for the key to show up need to increase sleep time