### PR TITLE
convert dns check to ssh instead of ping

### DIFF
--- a/test_orch/pkg-test.sls
+++ b/test_orch/pkg-test.sls
@@ -46,6 +46,7 @@ wait_for_dns:
     - tgt_type: list
     - sls:
       - test_orch.states.wait_for_dns
+    - timeout: 200
     - pillar:
         hostname: {{ host }}
 {% else %}

--- a/test_orch/states/wait_for_dns.sls
+++ b/test_orch/states/wait_for_dns.sls
@@ -2,10 +2,19 @@
 
 def run():
     config = {}
+    target_host = __pillar__['hostname']
     test = True
     while test == True:
-        query_dns = __salt__['cmd.retcode']('ping -c 1 {0}'.format(__pillar__['hostname']))
+        query_dns = __salt__['cmd.retcode']('salt-ssh {0} test.ping -i'.format(target_host))
         if query_dns == 0:
             test == False
             break
+
+    config['vm-created'] = {
+        'cmd': [
+            'run',
+            {'name': 'echo {0} VM has been created'.format(target_host)},
+        ],
+    }
+
     return config


### PR DESCRIPTION
Converts the check to a salt-ssh check since the ping was succeeding as soon as the network started on the VM but it had not started completely.