### PR TITLE
Remove manual restart of services after upgrade

### DIFF
--- a/test_install/saltstack/amazon.sls
+++ b/test_install/saltstack/amazon.sls
@@ -71,17 +71,6 @@ upgrade-salt:
   cmd.run:
     - name: yum -y update {{ params.pkgs | join(' ') }}
 
-{% set exists = salt['cmd.run']('pidof systemd') %}
-{% if not exists %}
-restart-salt:
-  cmd.run:
-    - names:
-      - service salt-master restart
-      - service salt-minion restart
-    - require:
-      - cmd: upgrade-salt
-{% endif %}
-
 {% else %}
 install-salt:
   cmd.run:

--- a/test_install/saltstack/debian.sls
+++ b/test_install/saltstack/debian.sls
@@ -52,17 +52,6 @@ upgrade-salt:
   cmd.run:
     - name: apt-get install -y -o Dpkg::Options::="--force-confdef" --only-upgrade {{ params.pkgs | join(' ') }}
 
-{% set exists = salt['cmd.run']('pgrep systemd') %}
-{% if not exists %}
-restart-salt:
-  cmd.run:
-    - names:
-      - service salt-master restart
-      - service salt-minion restart
-    - require:
-      - cmd: upgrade-salt
-{% endif %}
-
 {% else %}
 
 install-salt:

--- a/test_install/saltstack/rhel.sls
+++ b/test_install/saltstack/rhel.sls
@@ -73,17 +73,6 @@ upgrade-salt:
   cmd.run:
     - name: yum -y update {{ params.pkgs | join(' ') }}
 
-{% set exists = salt['cmd.run']('pidof systemd') %}
-{% if not exists %}
-restart-salt:
-  cmd.run:
-    - names:
-      - service salt-master restart
-      - service salt-minion restart
-    - require:
-      - cmd: upgrade-salt
-{% endif %}
-
 {% else %}
 install-salt:
   cmd.run:

--- a/test_install/saltstack/ubuntu.sls
+++ b/test_install/saltstack/ubuntu.sls
@@ -47,17 +47,6 @@ upgrade-salt:
   cmd.run:
     - name: apt-get install -y -o Dpkg::Options::="--force-confdef" --only-upgrade {{ params.pkgs | join(' ') }}
 
-{% set exists = salt['cmd.run']('pidof systemd') %}
-{% if not exists %}
-restart-salt:
-  cmd.run:
-    - names:
-      - service salt-master restart
-      - service salt-minion restart
-    - require:
-      - cmd: upgrade-salt
-{% endif %}
-
 {% else %}
 
 install-salt:


### PR DESCRIPTION
We should not be manually restarting the service after an upgrade. The condrestart in the postint script should handle the restart of the service if the service is already running. If we lose communication with the minion this is an issue. 

One issue I might see in this change is might have to have it sleep to wait for the restart if run into issues.