### PR TITLE
enable install of python-apt for all debian OSs

### DIFF
--- a/params.jinja
+++ b/params.jinja
@@ -59,6 +59,9 @@
 {# When using SaltStack repos, decide whether to use the 'latest' repo #}
 {% set use_latest = pillar.get('latest', False) %}
 {% set repo_version = 'latest' if use_latest else salt_version %}
+{% set repo_user= pillar.get('repo_user', '') %}
+{% set repo_passwd = pillar.get('repo_passwd', '') %}
+{% set repo_auth = repo_user + ':' + repo_passwd + '@' %}
 
 {# Set minion ID used for master<->local minion testing #}
 {% set minion_id = '{0}'.format(grains.get('id')) %}

--- a/test_install/saltstack/amazon.sls
+++ b/test_install/saltstack/amazon.sls
@@ -5,7 +5,7 @@
 {% set branch = params.salt_version.rsplit('.', 1)[0] %}
 
 {% if params.use_latest %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}yum/amazon/latest/$basearch/latest'.format(params.dev) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}yum/amazon/latest/$basearch/latest'.format(params.repo_auth, params.dev) %}
   {% set repo_pkg = 'salt-amzn-repo-{0}{1}.amzn1.noarch.rpm'.format(branch, params.repo_pkg_version) %}
   {% set repo_pkg_url = 'https://repo.saltstack.com/{0}yum/amazon/{1}'.format(params.dev, repo_pkg) %}
 {% elif params.test_rc_pkgs %}
@@ -13,15 +13,15 @@
   {% set repo_pkg = 'salt-amzn-repo-{0}{1}.amzn1.noarch.rpm'.format(branch, params.repo_pkg_version) %}
   {% set repo_pkg_url = 'https://repo.saltstack.com/{0}salt_rc/yum/amazon/{1}'.format(params.dev, repo_pkg) %}
 {% elif branch == '2016.3' %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}yum/redhat/6/$basearch/archive/{1}' %}
-  {% set repo_url = repo_url.format(params.dev, params.salt_version) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}yum/redhat/6/$basearch/archive/{2}' %}
+  {% set repo_url = repo_url.format(params.repo_auth, params.dev, params.salt_version) %}
   {% set repo_pkg = 'salt-amzn-repo-{0}{1}.ami.noarch.rpm'.format(branch, params.repo_pkg_version) %}
-  {% set repo_pkg_url = 'https://repo.saltstack.com/{0}yum/amazon/{1}'.format(params.dev, repo_pkg) %}
+  {% set repo_pkg_url = 'https://{0}repo.saltstack.com/{1}yum/amazon/{2}'.format(params.repo_auth, params.dev, repo_pkg) %}
 {% else %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}yum/amazon/latest/$basearch/archive/{1}' %}
-  {% set repo_url = repo_url.format(params.dev, params.salt_version) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}yum/amazon/latest/$basearch/archive/{2}' %}
+  {% set repo_url = repo_url.format(params.repo_auth, params.dev, params.salt_version) %}
   {% set repo_pkg = 'salt-amzn-repo-{0}{1}.amzn1.noarch.rpm'.format(branch, params.repo_pkg_version) %}
-  {% set repo_pkg_url = 'https://repo.saltstack.com/{0}yum/amazon/{1}'.format(params.dev, repo_pkg) %}
+  {% set repo_pkg_url = 'https://{0}repo.saltstack.com/{1}yum/amazon/{2}'.format(params.repo_auth, params.dev, repo_pkg) %}
 {% endif %}
 
 {% set key_name = 'SALTSTACK-GPG-KEY.pub' %}

--- a/test_install/saltstack/debian.sls
+++ b/test_install/saltstack/debian.sls
@@ -2,14 +2,14 @@
 {% import 'params.jinja' as params %}
 
 {% if params.use_latest %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}apt/debian/{1}/{2}/latest' %}
-  {% set repo_url = repo_url.format(params.dev, params.os_major_release, params.os_arch) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}apt/debian/{2}/{3}/latest' %}
+  {% set repo_url = repo_url.format(params.repo_auth, params.dev, params.os_major_release, params.os_arch) %}
 {% elif params.test_rc_pkgs %}
   {% set repo_url = 'https://repo.saltstack.com/{0}salt_rc/apt/debian/{1}/{2}/' %}
   {% set repo_url = repo_url.format(params.dev, params.os_major_release, params.os_arch) %}
 {% else %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}apt/debian/{1}/{2}/archive/{3}' %}
-  {% set repo_url = repo_url.format(params.dev, params.os_major_release, params.os_arch, params.salt_version) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}apt/debian/{2}/{3}/archive/{4}' %}
+  {% set repo_url = repo_url.format(params.repo_auth, params.dev, params.os_major_release, params.os_arch, params.salt_version) %}
 {% endif %}
 
 {% set key_url = '{0}/SALTSTACK-GPG-KEY.pub'.format(repo_url) %}
@@ -17,7 +17,6 @@
 {% if params.on_deb_7 %}
 {% set key_url = 'http://' + key_url.split('https://')[1] %}
 {% endif %}
-{% set repo_url = 'http://' + repo_url.split('https://')[1] %}
 
 install-python-apt:
   pkg.installed:

--- a/test_install/saltstack/debian.sls
+++ b/test_install/saltstack/debian.sls
@@ -19,11 +19,9 @@
 {% endif %}
 {% set repo_url = 'http://' + repo_url.split('https://')[1] %}
 
-{% if params.os == 'Raspbian' %}
 install-python-apt:
   pkg.installed:
     - name: python-apt
-{% endif %}
 
 pre_update-package-database:
   module.run:

--- a/test_install/saltstack/rhel.sls
+++ b/test_install/saltstack/rhel.sls
@@ -19,12 +19,12 @@
 {% set release = 6 if params.on_amazon else '$releasever' %}
 
 {% if params.use_latest %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}yum/redhat/{1}/$basearch/latest'.format(params.dev, release) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}yum/redhat/{2}/$basearch/latest'.format(params.repo_auth, params.dev, release) %}
 {% elif params.test_rc_pkgs %}
   {% set repo_url = 'https://repo.saltstack.com/{0}salt_rc/yum/redhat/{1}/$basearch'.format(params.dev, release) %}
 {% else %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}yum/redhat/{1}/$basearch/archive/{2}' %}
-  {% set repo_url = repo_url.format(params.dev, release, params.salt_version) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}yum/redhat/{2}/$basearch/archive/{3}' %}
+  {% set repo_url = repo_url.format(params.repo_auth, params.dev, release, params.salt_version) %}
 {% endif %}
 
 {% set key_name = 'SALTSTACK-EL5-GPG-KEY.pub' if params.on_rhel_5 else 'SALTSTACK-GPG-KEY.pub' %} 

--- a/test_install/saltstack/ubuntu.sls
+++ b/test_install/saltstack/ubuntu.sls
@@ -2,14 +2,14 @@
 {% import 'params.jinja' as params %}
 
 {% if params.use_latest %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}apt/ubuntu/{1}/{2}/latest' %}
-  {% set repo_url = repo_url.format(params.dev, params.os_release, params.os_arch) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}apt/ubuntu/{2}/{3}/latest' %}
+  {% set repo_url = repo_url.format(params.repo_user, params.dev, params.os_release, params.os_arch) %}
 {% elif params.test_rc_pkgs %}
   {% set repo_url = 'https://repo.saltstack.com/{0}salt_rc/apt/ubuntu/{1}/{2}/' %}
   {% set repo_url = repo_url.format(params.dev, params.os_release, params.os_arch) %}
 {% else %}
-  {% set repo_url = 'https://repo.saltstack.com/{0}apt/ubuntu/{1}/{2}/archive/{3}' %}
-  {% set repo_url = repo_url.format(params.dev, params.os_release, params.os_arch, params.salt_version) %}
+  {% set repo_url = 'https://{0}repo.saltstack.com/{1}apt/ubuntu/{2}/{3}/archive/{4}' %}
+  {% set repo_url = repo_url.format(params.repo_auth, params.dev, params.os_release, params.os_arch, params.salt_version) %}
 {% endif %}
 
 {% set key_url = '{0}/SALTSTACK-GPG-KEY.pub'.format(repo_url) %}


### PR DESCRIPTION
The Debian9 image we are using in particular does not have python-apt installed and its needed for the pkgrepo.managed state. This will also ensure its installed on any other Debian image. 