### PR TITLE
Change os_major_release check to int

### DIFF
--- a/params.jinja
+++ b/params.jinja
@@ -32,7 +32,7 @@
 {# Python versions #}
 {% set python_version = 'python' %}
 {% if '2016' not in salt_version %}
-  {% if os_major_release == '6' %}
+  {% if os_major_release == 6 %}
     {% set python_version = 'python2.7' %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
In 2017.7.0 Salt Release osmajorrelease grains was changed from a string to an int. Need to check for 6 int instead of string in order for this python_version set to work.