### PR TITLE
Remove old fips workaround

### DIFF
--- a/test_setup/init.sls
+++ b/test_setup/init.sls
@@ -5,11 +5,10 @@
 {% set fips_enabled = salt['cmd.run']('cat /proc/sys/crypto/fips_enabled') %}
 
 {% if fips_enabled == '1' %}
-fips_workaround:
+fips_is_enabled:
   cmd.run:
     - names:
-      - rpm -e --nodeps python2-pycryptodomex
-      - yum install python-crypto -y
+      - echo testing_fips
 {% endif %}
 
 {% if params.on_smartos %}


### PR DESCRIPTION
We no longer need to use the fips workaround but we still want to be able to see if the VM is indeed fips enabled so keeping this check here.