### PR TITLE
miscellaneous fixes for api and systemd checks

### DIFF
--- a/params.jinja
+++ b/params.jinja
@@ -150,7 +150,7 @@
 {# salt-api variables #}
 {% set api_user = 'saltdev' %}
 {% set api_passwd = 'saltdev' %}
-{% set api_config = '/etc/salt/master' %}
+{% set api_config = '/etc/salt/master.d/api.conf' %}
 
 {# minion-only variables #}
 {% set master_host = salt['pillar.get']('master_host') %}

--- a/test_orch/pkg-test.sls
+++ b/test_orch/pkg-test.sls
@@ -157,6 +157,7 @@ test_run_{{ action }}:
         dev: {{ dev }}
         repo_user: {{ repo_user }}
         repo_passwd: {{ repo_passwd }}
+        upgrade: {{ upgrade_val }}
 {%- endmacro %}
 
 {% macro clean_up(action='None') -%}

--- a/test_run/api.sls
+++ b/test_run/api.sls
@@ -7,5 +7,5 @@ query_api:
     - method: POST
     - header_list: '["Accept: application/json"]'
     - verify_ssl: False
-    - data: 'username={{ params.api_user }}&password={{ params.api_passwd }}&eauth=pam&client=local&tgt=*&fun=test.ping'
+    - data: 'username={{ params.api_user }}&password={{ params.api_passwd }}&eauth=pam&client=local&tgt=*&fun=test.ping&timeout=30'
     - status: 200

--- a/test_run/files/systemd_script.sh
+++ b/test_run/files/systemd_script.sh
@@ -14,8 +14,14 @@ check_systemd_config() {
 
 SYSTEMD_CMD='systemctl'
 if type "${SYSTEMD_CMD}" > /dev/null; then
+  if $(salt-call --local test.version |grep 2016 > /dev/null); then
     check_systemd_config KillMode control-group
+  elif $(salt-call --local test.version |grep 2017.7.2 > /dev/null); then
+    check_systemd_config KillMode control-group
+  else
+    check_systemd_config KillMode process
     check_systemd_config Type notify
+  fi
 else
     (>&2 echo "systemctl does not exist. systemd is not on this vm. SKIPPING TEST")
 fi

--- a/test_run/init.sls
+++ b/test_run/init.sls
@@ -1,7 +1,13 @@
 {# Import global parameters that source from grains and pillars #}
 {% import 'params.jinja' as params %}
+{% set systemd_exists = salt['cmd.run']('pidof systemd') %}
+{% set upgrade = salt['pillar.get']('upgrade') %}
 
 include:
+{# restart services that don't auto start on upgrade #}
+{% if ('2016' in params.salt_version or not systemd_exists) and upgrade %}
+  - test_run.restart_services
+{% endif %}
 {% if params.minion_only %}
 {# minion only #}
   - test_run.minion_only

--- a/test_run/restart_services.sls
+++ b/test_run/restart_services.sls
@@ -1,0 +1,13 @@
+{% set restart_services = ['salt-api'] %}
+
+{% for service in restart_services %}
+restart_{{ service }}:
+  module.run:
+    - name: service.restart
+    - m_name: {{ service }}
+
+sleep_wait_for_restart_{{ service }}:
+  module.run:
+    - name: test.sleep
+    - length: 10
+{% endfor %}

--- a/test_setup/init.sls
+++ b/test_setup/init.sls
@@ -7,7 +7,7 @@ include:
   - test_setup.minion_only
 {% else %}
   - test_setup.master_minion
-{% if params.os in ('CentOS', 'Redhat', 'Amazon', 'Debian', 'Ubuntu') %}
+{% if params.os in ('CentOS', 'RedHat', 'Amazon', 'Debian', 'Ubuntu') %}
   - test_setup.api
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Includes following changes:
1: change api config to /etc/salt/master.d/api.conf
2. increase the query to the api 's timeout to 30
3. change the systemd killmode check to check for process instead of control-group (https://github.com/saltstack/salt/pull/44427)
4. restart salt-api service if not on systemd VM 
